### PR TITLE
Fix circular dependencies to resolve stack overflow

### DIFF
--- a/Configuration/.cproject
+++ b/Configuration/.cproject
@@ -83,25 +83,7 @@
 					</folderInfo>
 				</configuration>
 			</storageModule>
-			<storageModule moduleId="org.eclipse.cdt.core.externalSettings">
-				<externalSettings containerId="Libraries;" factoryId="org.eclipse.cdt.core.cfg.export.settings.sipplier">
-					<externalSetting>
-						<entry flags="VALUE_WORKSPACE_PATH" kind="includePath" name="/Libraries"/>
-						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="includePath" name="/Libraries/FreeRTOS-Plus-TCP-multi-master/source/portable/Compiler/GCC"/>
-						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="includePath" name="/Libraries/FreeRTOS-Plus-TCP-multi-master/include"/>
-						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="includePath" name="/Libraries/dLAN_Green_PHY_eval_board/inc"/>
-						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="includePath" name="/Libraries/lpc_chip_175x_6x/inc"/>
-						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="includePath" name="/Libraries/FreeRTOS-Plus-TCP-multi-master/source/portable/FileSystem/httpd-fs"/>
-						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="includePath" name="/Libraries/FreeRTOS-Plus-TCP-multi-master/source/protocols/include"/>
-						<entry flags="RESOLVED" kind="macro" name="CORE_M3" value=""/>
-						<entry flags="RESOLVED" kind="macro" name="__USE_LPCOPEN" value=""/>
-						<entry flags="RESOLVED" kind="macro" name="__REDLIB__" value=""/>
-						<entry flags="RESOLVED" kind="macro" name="__CODE_RED" value=""/>
-						<entry flags="VALUE_WORKSPACE_PATH" kind="libraryPath" name="/Libraries/Release"/>
-						<entry flags="RESOLVED" kind="libraryFile" name="Libraries" srcPrefixMapping="" srcRootPath=""/>
-					</externalSetting>
-				</externalSettings>
-			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
 		</cconfiguration>
 		<cconfiguration id="com.crt.advproject.config.lib.debug.1897047041.2051660535">
 			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.lib.debug.1897047041.2051660535" moduleId="org.eclipse.cdt.core.settings" name="Release">

--- a/Configuration/.project
+++ b/Configuration/.project
@@ -3,7 +3,6 @@
 	<name>Configuration</name>
 	<comment></comment>
 	<projects>
-		<project>Libraries</project>
 	</projects>
 	<buildSpec>
 		<buildCommand>

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ There are also binaries of the stock-firmware (v1.0.16) with the bootloader and 
 ## Requirements
 * [dLAN® Green PHY module](https://www.devolo.de/dlan-green-phy-module) with a development board, e.g. the [dLAN® 
 Green PHY eval board II](https://www.devolo.de/dlan-green-phy-eval-board-ii), or your own design
-* [MCUXpresso IDE](https://www.nxp.com/products/developer-resources/run-time-software/mcuxpresso-software-and-tools/mcuxpresso-integrated-development-environment-ide-v10.0.2:MCUXpresso-IDE) *(tested for v11.1.0, not working with v11.2.1)*
+* [MCUXpresso IDE](https://www.nxp.com/design/software/development-software/mcuxpresso-software-and-tools-/mcuxpresso-integrated-development-environment-ide:MCUXpresso-IDE)
 * JTAG-Debugger, recommended [LPC-Link 
 2](https://www.nxp.com/products/developer-resources/software-development-tools/developer-resources-/lpcopen-libraries-and-examples/lpc-link2:OM13054) 
 with [ARM-JTAG-20-10 Adapter](https://www.olimex.com/Products/ARM/JTAG/ARM-JTAG-20-10/)


### PR DESCRIPTION
Newer versions of MCUxpressIDE can't deal with circular project dependencies.